### PR TITLE
Comparison method on WeightedStep causes problems on JDK1.7

### DIFF
--- a/org.jbehave.eclipse/src/org/jbehave/eclipse/editor/step/WeightedStep.java
+++ b/org.jbehave.eclipse/src/org/jbehave/eclipse/editor/step/WeightedStep.java
@@ -7,14 +7,14 @@ public class WeightedStep implements Comparable<WeightedStep>, HasHTMLComment {
 	public final StepCandidate stepCandidate;
 	public final float weight;
 
-	public WeightedStep(StepCandidate stepCandidate, float weight) {
+	public WeightedStep(final StepCandidate stepCandidate, final float weight) {
 		this.stepCandidate = stepCandidate;
 		this.weight = weight;
 	}
 
 	@Override
-	public int compareTo(WeightedStep o) {
-		return (weight > o.weight) ? 1 : -1;
+	public int compareTo(final WeightedStep o) {
+		return Float.compare(weight, o.weight);
 	}
 
 	private String htmlComment;

--- a/org.jbehave.eclipse/test/org/jbehave/eclipse/editor/step/WeightedStepTest.java
+++ b/org.jbehave.eclipse/test/org/jbehave/eclipse/editor/step/WeightedStepTest.java
@@ -1,0 +1,32 @@
+package org.jbehave.eclipse.editor.step;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+public class WeightedStepTest {
+
+  @Test
+  public void testSorting() {
+    WeightedStep s1 = new WeightedStep(null, 1.1f);
+    WeightedStep s1Also = new WeightedStep(null, 1.1f);
+    WeightedStep s2 = new WeightedStep(null, 1.2f);
+    WeightedStep s3 = new WeightedStep(null, 1.3f);
+
+    List<WeightedStep> list = Lists.newArrayList(s1, s3, s2, s1Also);
+    Collections.sort(list);
+
+    // Note we expect the relative ordering of s1Also and s1 to be preserved as they're equal
+    List<WeightedStep> expectedSortOrder = ImmutableList.of(s1, s1Also, s2, s3);
+    assertEquals(expectedSortOrder, list);
+
+    assertEquals(0, s1.compareTo(s1Also));
+  }
+
+}


### PR DESCRIPTION
The attached changes fix the following stack trace seen using the plugin on JDK 1.7:

java.lang.IllegalArgumentException: Comparison method violates its
general contract!
at java.util.ComparableTimSort.mergeHi(ComparableTimSort.java:835)
at java.util.ComparableTimSort.mergeAt(ComparableTimSort.java:453)
at
java.util.ComparableTimSort.mergeForceCollapse(ComparableTimSort.java:392)
at java.util.ComparableTimSort.sort(ComparableTimSort.java:191)
at java.util.ComparableTimSort.sort(ComparableTimSort.java:146)
at java.util.Arrays.sort(Arrays.java:472)
at java.util.Collections.sort(Collections.java:155)
at
org.technbolts.jbehave.eclipse.editors.story.completion.StepContentAssistProcessor.computeCompletionProposals(StepContentAssistProcessor.java:113)
at
org.eclipse.jface.text.contentassist.ContentAssistant.computeCompletionProposals(ContentAssistant.java:1830)
at
org.eclipse.jface.text.contentassist.CompletionProposalPopup.computeProposals(CompletionProposalPopup.java:556)
at
org.eclipse.jface.text.contentassist.CompletionProposalPopup.access$16(CompletionProposalPopup.java:553)
at
org.eclipse.jface.text.contentassist.CompletionProposalPopup$2.run(CompletionProposalPopup.java:488)
at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
at
org.eclipse.jface.text.contentassist.CompletionProposalPopup.showProposals(CompletionProposalPopup.java:482)
at
org.eclipse.jface.text.contentassist.ContentAssistant.showPossibleCompletions(ContentAssistant.java:1656)
at
org.eclipse.jface.text.source.SourceViewer.doOperation(SourceViewer.java:930)
at
org.eclipse.ui.texteditor.ContentAssistAction$1.run(ContentAssistAction.java:82)
at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:70)
at
org.eclipse.ui.texteditor.ContentAssistAction.run(ContentAssistAction.java:80)
at org.eclipse.jface.action.Action.runWithEvent(Action.java:498)
at org.eclipse.ui.commands.ActionHandler.execute(ActionHandler.java:185)
at
org.eclipse.ui.internal.handlers.LegacyHandlerWrapper.execute(LegacyHandlerWrapper.java:109)
at org.eclipse.core.commands.Command.executeWithChecks(Command.java:476)
at
org.eclipse.core.commands.ParameterizedCommand.executeWithChecks(ParameterizedCommand.java:508)
at
org.eclipse.ui.internal.handlers.HandlerService.executeCommand(HandlerService.java:169)
at
org.eclipse.ui.internal.keys.WorkbenchKeyboard.executeCommand(WorkbenchKeyboard.java:468)
at
org.eclipse.ui.internal.keys.WorkbenchKeyboard.press(WorkbenchKeyboard.java:786)
at
org.eclipse.ui.internal.keys.WorkbenchKeyboard.processKeyEvent(WorkbenchKeyboard.java:885)
at
org.eclipse.ui.internal.keys.WorkbenchKeyboard.filterKeySequenceBindings(WorkbenchKeyboard.java:567)
at
org.eclipse.ui.internal.keys.WorkbenchKeyboard.access$3(WorkbenchKeyboard.java:508)
at
org.eclipse.ui.internal.keys.WorkbenchKeyboard$KeyDownFilter.handleEvent(WorkbenchKeyboard.java:123)
at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
at org.eclipse.swt.widgets.Display.filterEvent(Display.java:1531)
at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1257)
at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1282)
at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1267)
at org.eclipse.swt.widgets.Widget.sendKeyEvent(Widget.java:1294)
at org.eclipse.swt.widgets.Widget.gtk_key_press_event(Widget.java:730)
at
org.eclipse.swt.widgets.Control.gtk_key_press_event(Control.java:3019)
at
org.eclipse.swt.widgets.Composite.gtk_key_press_event(Composite.java:734)
at org.eclipse.swt.widgets.Widget.windowProc(Widget.java:1743)
at org.eclipse.swt.widgets.Control.windowProc(Control.java:5016)
at org.eclipse.swt.widgets.Display.windowProc(Display.java:4408)
at org.eclipse.swt.internal.gtk.OS._gtk_main_do_event(Native Method)
at org.eclipse.swt.internal.gtk.OS.gtk_main_do_event(OS.java:8422)
at org.eclipse.swt.widgets.Display.eventProc(Display.java:1245)
at org.eclipse.swt.internal.gtk.OS._g_main_context_iteration(Native
Method)
at
org.eclipse.swt.internal.gtk.OS.g_main_context_iteration(OS.java:2276)
at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3207)
at org.eclipse.ui.internal.Workbench.runEventLoop(Workbench.java:2701)
at org.eclipse.ui.internal.Workbench.runUI(Workbench.java:2665)
at org.eclipse.ui.internal.Workbench.access$4(Workbench.java:2499)
at org.eclipse.ui.internal.Workbench$7.run(Workbench.java:679)
at
org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
at
org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:668)
at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:149)
at
org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:123)
at
org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
at
org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:110)
at
org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:79)
at
org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:344)
at
org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:179)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
at
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:601)
at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:622)
at org.eclipse.equinox.launcher.Main.basicRun(Main.java:577)
at org.eclipse.equinox.launcher.Main.run(Main.java:1410)
